### PR TITLE
Add waterfallize to the benchmark script

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -5,6 +5,7 @@ var insync = require('insync')
 var neoAsync = require('neo-async')
 var fall = require('./')()
 var runWaterfall = require('run-waterfall')
+var waterfallize = require('waterfallize')
 
 function bench (func, done) {
   var key = max + '*' + func.name
@@ -60,6 +61,15 @@ function benchFastFall (done) {
   fall(toCall, done)
 }
 
+function benchWaterfallize (done) {
+  var next = waterfallize()
+
+  next(toCall[0])
+  next(toCall[1])
+  next(toCall[2])
+  next(done)
+}
+
 function benchRunWaterFall (done) {
   runWaterfall(toCall, done)
 }
@@ -84,6 +94,7 @@ function run (next) {
     benchFastFall,
     benchRunWaterFall,
     benchSetImmediate,
+    benchWaterfallize,
     compiled
   ], next || noop)
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "pre-commit": "^1.0.10",
     "run-waterfall": "^1.1.1",
     "standard": "^4.2.1",
-    "tape": "^4.0.0"
+    "tape": "^4.0.0",
+    "waterfallize": "^1.0.0"
   }
 }


### PR DESCRIPTION
Hey again! I've added [waterfallize](https://github.com/alessioalex/waterfallize) to the benchmarks here as well. Just like [parallelize](https://github.com/parallelize) it has a different syntax than `fastfall` or `async`, but a little perspective is nice.
