### PR TITLE
adhere to padded-blocks

### DIFF
--- a/fall.js
+++ b/fall.js
@@ -3,7 +3,6 @@
 var empty = []
 
 function fastfall (context, template) {
-
   if (Array.isArray(context)) {
     template = context
     context = null


### PR DESCRIPTION
We are in the process of adding back the rule `padded-blocks` into `standard`. It was temporarily disabled because of a bug in eslint which now has been fixed.

This pull request makes sure that your coding style is compliant with the new version.

Please see feross/standard#170 for more info.
