### PR TITLE
standard style: indentation

### DIFF
--- a/example.js
+++ b/example.js
@@ -14,6 +14,7 @@ fall([
   function c (a, b, cb) {
     console.log('called c with:', a, b)
     cb(null, 'a', 'b', 'c')
-  }], function result (err, a, b, c) {
+  }],
+  function result (err, a, b, c) {
     console.log('result arguments', err, a, b, c)
   })


### PR DESCRIPTION
This fixes the following linting errors that previously occurred:

``` text
standard: Use JavaScript Standard Style (https://github.com/feross/standard) 
  fastfall/example.js:18:5: Expected indentation of 2 space characters but found 4.
  fastfall/example.js:19:3: Expected indentation of 0 space characters but found 2.
```
