### PR TITLE
Unroll loop and use call when possible

### DIFF
--- a/fall.js
+++ b/fall.js
@@ -72,20 +72,55 @@ function Holder () {
       return that.callback.call(that.context, arguments[0])
     }
 
-    var args = []
-    var i = 0
+    var len = arguments.length
+    var i
+    var args
+    var func
 
     if (that.count < that.list.length) {
-      for (i = 1; i < arguments.length; i++) {
-        args[i - 1] = arguments[i]
+      func = that.list[that.count++]
+      switch (len) {
+        case 0:
+        case 1:
+          return func.call(that.context, work)
+        case 2:
+          return func.call(that.context, arguments[1], work)
+        case 3:
+          return func.call(that.context, arguments[1], arguments[2], work)
+        case 4:
+          return func.call(that.context, arguments[1], arguments[2], arguments[3], work)
+        default:
+          args = new Array(len)
+          for (i = 1; i < len; i++) {
+            args[i - 1] = arguments[i]
+          }
+          args[len - 1] = work
+          func.apply(that.context, args)
       }
-      args[args.length] = work
-      that.list[that.count++].apply(that.context, args)
     } else {
-      for (i = 0; i < arguments.length; i++) {
-        args[i] = arguments[i]
+      switch (len) {
+        case 0:
+          that.callback.call(that.context)
+          break
+        case 1:
+          that.callback.call(that.context, arguments[0])
+          break
+        case 2:
+          that.callback.call(that.context, arguments[0], arguments[1])
+          break
+        case 3:
+          that.callback.call(that.context, arguments[0], arguments[1], arguments[2])
+          break
+        case 4:
+          that.callback.call(that.context, arguments[0], arguments[1], arguments[2], arguments[3])
+          break
+        default:
+          args = new Array(len)
+          for (i = 0; i < len; i++) {
+            args[i] = arguments[i]
+          }
+          that.callback.apply(that.context, args)
       }
-      that.callback.apply(that.context, args)
       that.context = undefined
       that.list = empty
       that.count = 0

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ var test = require('tape')
 var fastfall = require('./')
 
 test('basically works', function (t) {
-  t.plan(7)
+  t.plan(22)
 
   var fall = fastfall()
 
@@ -20,12 +20,36 @@ test('basically works', function (t) {
       t.equal(a, 'a', 'third function 1st arg matches')
       t.equal(b, 'b', 'third function 2nd arg matches')
       cb(null, 'a', 'b', 'c')
+    },
+    function d (a, b, c, cb) {
+      t.equal(a, 'a', 'fourth function 1st arg matches')
+      t.equal(b, 'b', 'fourth function 2nd arg matches')
+      t.equal(c, 'c', 'fourth function 3rd arg matches')
+      cb(null, 'a', 'b', 'c', 'd')
+    },
+    function e (a, b, c, d, cb) {
+      t.equal(a, 'a', 'fifth function 1st arg matches')
+      t.equal(b, 'b', 'fifth function 2nd arg matches')
+      t.equal(c, 'c', 'fifth function 3rd arg matches')
+      t.equal(d, 'd', 'fifth function 4th arg matches')
+      cb(null, 'a', 'b', 'c', 'd', 'e')
+    },
+    function f (a, b, c, d, e, cb) {
+      t.equal(a, 'a', 'sixth function 1st arg matches')
+      t.equal(b, 'b', 'sixth function 2nd arg matches')
+      t.equal(c, 'c', 'sixth function 3rd arg matches')
+      t.equal(d, 'd', 'sixth function 4th arg matches')
+      t.equal(e, 'e', 'sixth function 5th arg matches')
+      cb(null, 'a', 'b', 'c', 'd', 'e', 'f')
     }
-  ], function result (err, a, b, c) {
+  ], function result (err, a, b, c, d, e, f) {
     t.error(err, 'no error')
     t.equal(a, 'a', 'result function 2nd arg matches')
     t.equal(b, 'b', 'result function 3rd arg matches')
     t.equal(c, 'c', 'result function 4th arg matches')
+    t.equal(d, 'd', 'result function 5th arg matches')
+    t.equal(e, 'e', 'result function 6th arg matches')
+    t.equal(f, 'f', 'result function 7th arg matches')
   })
 })
 


### PR DESCRIPTION
I've unrolled the loop used to create the arguments with a switch, in this way for simple cases we don't need to instantiate an array and we can use call instead of apply.

I've also expanded the tests to make sure the both the "fast" path (switch) and the "standard" slow (loop) are tested.

On my setup this shaves ~10% of execution time.
